### PR TITLE
Fixed missing arg

### DIFF
--- a/comparisons/classes/subclass/swift.scala
+++ b/comparisons/classes/subclass/swift.scala
@@ -30,6 +30,6 @@ class Square: NamedShape {
     }
 }
 
-let test = Square(sideLength: 5.2)
+let test = Square(sideLength: 5.2, name: "my test square")
 test.area()
 test.simpleDescription()


### PR DESCRIPTION
Hi! I like this comparison! 
I think I found a minor issue, corrected by this PR.

Also, how about adding a pattern match part as well?
I guess that is the way you typically check types and downcast (at least in Scala?). I do not have the Beta 3 so cannot try it out but I guess it would be something like:

``` scala
var movieCount = 0
var songCount = 0

for (item <- library) {
  item match {
    case movie: Movie =>
      movieCount += 1
      println(s"Movie: '${movie.name}', dir. ${movie.director}")
    case song: Song =>
      songCount += 1
      println(s"Song: '${song.title}'")
  }
}
```

``` swift
var movieCount = 0
var songCount = 0

for item in library {
  switch item {
    case let movie as Movie:
      ++movieCount
      println("Movie: '\(movie.name)', dir. \(movie.director)")
    case let song as Song:
      ++songCount
      println("Song: '\(song.title)'")
  }
}
```
